### PR TITLE
Include header cells in rows when parsing HTML

### DIFF
--- a/mtable.py
+++ b/mtable.py
@@ -511,8 +511,8 @@ class MarkupTable(object):
                             row.extend([' '] * (int(th.get('colspan')) - 1))
                     mt.feed_header(row)
                     column_count = len(row)
-                elif tr.find('td'):
-                    for td in tr.find_all('td'):
+                elif tr.find(['th', 'td']):
+                    for td in tr.find_all(['th', 'td']):
                         text = strip_text(' '.join(td.stripped_strings))
                         row.append(text)
                         if td.get('colspan'):


### PR DESCRIPTION
When converting HTML tables with row header cells, the row header cells are skipped, resulting in misaligned column headers:

This PR fixes this issue.

Before:
![image](https://user-images.githubusercontent.com/12154190/144719693-c80ee295-993b-4e0c-9a8a-b5e098f29f74.png)


After:
![image](https://user-images.githubusercontent.com/12154190/144719667-a21c99bd-669a-46d1-8788-1d16d293f424.png)