### PR TITLE
Exclude quotes when parsing verion number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 with open('mtable.py') as f:
     content = f.read()
-    mo = re.search(r"VERSION = ('[\d\.]+')\n", content)
+    mo = re.search(r"VERSION = '([\d\.]+)'\n", content)
     VERSION = mo.group(1)
 
 with open('README.rst') as f:


### PR DESCRIPTION
Hello,

I've been having problems depending on this package as the version number is not [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant.

When running `setup.py`, the following warning is shown:

```
/lib/python3.8/site-packages/setuptools/dist.py:477: UserWarning: The version specified ("'0.1.21'") is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
```

The issue is that the regex you use to extract the package version number includes the quotation marks, resulting in an invalid version number (`'0.1.21'` instead of `0.1.21`).

This PR corrects the regex in `setup.py`.

Thanks

---

P.S. Would you consider uploading a new release of `mtable` to PyPI?